### PR TITLE
Fix decoding problems for non ascii languages

### DIFF
--- a/hent/console_script.py
+++ b/hent/console_script.py
@@ -119,7 +119,7 @@ def distro():
 
 
 def uptime():
-    cmd = subprocess.run(['uptime', '--pretty'], capture_output=True)
+    cmd = subprocess.run(['uptime', '--pretty'], capture_output=True, env={"LANG": "C"})
     return cmd.stdout.decode('ascii')[3:-1]
 
 
@@ -127,7 +127,7 @@ def count_pkgs():
     output = {}
     for manager, command in PKGS.items():
         try:
-            cmd = subprocess.run(command, capture_output=True)
+            cmd = subprocess.run(command, capture_output=True, env={"LANG": "C"})
             output[manager] = cmd.stdout.decode('ascii').count('\n')
         except FileNotFoundError:
             pass
@@ -170,7 +170,7 @@ def ram():
 
 
 def gpu():
-    cmd = subprocess.run(['lspci'], capture_output=True)
+    cmd = subprocess.run(['lspci'], capture_output=True, env={"LANG": "C"})
     stdout = cmd.stdout.decode('ascii')
 
     for line in stdout.splitlines():

--- a/hent/console_script.py
+++ b/hent/console_script.py
@@ -170,7 +170,7 @@ def ram():
 
 
 def gpu():
-    cmd = subprocess.run(['lspci'], capture_output=True, env={"LANG": "C"})
+    cmd = subprocess.run(['lspci'], capture_output=True)
     stdout = cmd.stdout.decode('ascii')
 
     for line in stdout.splitlines():


### PR DESCRIPTION
When `LANG='es_ES.UTF-8'` you could get an error like:

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2387: ordinal not in range(128)` 

This avoids it changing `LANG` to `C` in the `subprocess` calls